### PR TITLE
Ros2 port of map_msgs

### DIFF
--- a/map_msgs/CMakeLists.txt
+++ b/map_msgs/CMakeLists.txt
@@ -1,41 +1,45 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
+
 project(map_msgs)
 
-find_package(catkin REQUIRED
-  COMPONENTS
-    std_msgs
-    sensor_msgs
-    nav_msgs
-    message_generation
+# Default to C++14
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 14)
+endif()
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  # we dont use add_compile_options with pedantic in message packages
+  # because the Python C extensions dont comply with it
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wpedantic")
+endif()
+
+find_package(ament_cmake REQUIRED)
+find_package(rosidl_default_generators REQUIRED)
+
+find_package(nav_msgs REQUIRED)
+find_package(sensor_msgs REQUIRED)
+find_package(std_msgs REQUIRED)
+
+set(msg_files
+  "msg/OccupancyGridUpdate.msg"
+  "msg/PointCloud2Update.msg"
+  "msg/ProjectedMapInfo.msg"
+  "msg/ProjectedMap.msg"
+)
+set(srv_files
+  "srv/GetMapROI.srv"
+  "srv/GetPointMapROI.srv"
+  "srv/GetPointMap.srv"
+  "srv/ProjectedMapsInfo.srv"
+  "srv/SaveMap.srv"
+  "srv/SetMapProjections.srv"
+)
+rosidl_generate_interfaces(${PROJECT_NAME}
+  ${msg_files}
+  ${srv_files}
+  DEPENDENCIES nav_msgs sensor_msgs std_msgs
+  ADD_LINTER_TESTS
 )
 
-add_message_files(
-  FILES
-    OccupancyGridUpdate.msg
-    PointCloud2Update.msg
-    ProjectedMapInfo.msg
-    ProjectedMap.msg
-)
-add_service_files(
-  FILES
-    GetMapROI.srv
-    GetPointMapROI.srv
-    GetPointMap.srv
-    ProjectedMapsInfo.srv
-    SaveMap.srv
-    SetMapProjections.srv
-)
+ament_export_dependencies(rosidl_default_runtime)
 
-generate_messages(
-  DEPENDENCIES
-    std_msgs
-    sensor_msgs
-    nav_msgs
-)
-
-catkin_package(
-  CATKIN_DEPENDS
-    std_msgs
-    sensor_msgs
-    nav_msgs
-)
+ament_package()

--- a/map_msgs/msg/OccupancyGridUpdate.msg
+++ b/map_msgs/msg/OccupancyGridUpdate.msg
@@ -1,4 +1,4 @@
-Header header
+std_msgs/Header header
 int32 x
 int32 y
 uint32 width

--- a/map_msgs/msg/PointCloud2Update.msg
+++ b/map_msgs/msg/PointCloud2Update.msg
@@ -1,5 +1,5 @@
 uint32 ADD=0
 uint32 DELETE=1
-Header header
+std_msgs/Header header
 uint32 type          # type of update, one of ADD or DELETE
 sensor_msgs/PointCloud2 points

--- a/map_msgs/package.xml
+++ b/map_msgs/package.xml
@@ -1,27 +1,27 @@
 <package>
-   <name>map_msgs</name>
-   <version>1.13.0</version>
-   <description>
-      This package defines messages commonly used in mapping packages.
-   </description>
-   <author>Stéphane Magnenat</author>
-   <maintainer email="davidvlu@gmail.com">David V. Lu!!</maintainer>
-   <maintainer email="mferguson@fetchrobotics.com">Michael Ferguson</maintainer>
+    <name>map_msgs</name>
+    <version>1.13.0</version>
+    <description>
+        This package defines messages commonly used in mapping packages.
+    </description>
+    <author>Stéphane Magnenat</author>
+    <maintainer email="davidvlu@gmail.com">David V. Lu!!</maintainer>
+    <maintainer email="mferguson@fetchrobotics.com">Michael Ferguson</maintainer>
 
-   <license>BSD</license>
-   <url type="website">http://ros.org/wiki/map_msgs</url>
-   <url type="bugtracker">https://github.com/ros-planning/navigation_msgs/issues</url>
+    <license>BSD</license>
+    <url type="website">http://ros.org/wiki/map_msgs</url>
+    <url type="bugtracker">https://github.com/ros-planning/navigation_msgs/issues</url>
 
-   <buildtool_depend>catkin</buildtool_depend>
+    <buildtool_depend>catkin</buildtool_depend>
 
-   <build_depend>message_generation</build_depend>
-   <build_depend>std_msgs</build_depend>
-   <build_depend>sensor_msgs</build_depend>
-   <build_depend>nav_msgs</build_depend>
+    <build_depend>message_generation</build_depend>
+    <build_depend>std_msgs</build_depend>
+    <build_depend>sensor_msgs</build_depend>
+    <build_depend>nav_msgs</build_depend>
 
-   <run_depend>message_runtime</run_depend>
-   <run_depend>std_msgs</run_depend>
-   <run_depend>sensor_msgs</run_depend>
-   <run_depend>nav_msgs</run_depend>
+    <run_depend>message_runtime</run_depend>
+    <run_depend>std_msgs</run_depend>
+    <run_depend>sensor_msgs</run_depend>
+    <run_depend>nav_msgs</run_depend>
 
 </package>

--- a/map_msgs/package.xml
+++ b/map_msgs/package.xml
@@ -1,27 +1,37 @@
-<package>
+<?xml version="1.0"?>
+<?xml-model
+    href="http://download.ros.org/schema/package_format3.xsd"
+    schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
     <name>map_msgs</name>
-    <version>1.13.0</version>
+    <version>2.0.0</version>
     <description>
         This package defines messages commonly used in mapping packages.
     </description>
     <author>Stéphane Magnenat</author>
     <maintainer email="davidvlu@gmail.com">David V. Lu!!</maintainer>
     <maintainer email="mferguson@fetchrobotics.com">Michael Ferguson</maintainer>
+    <maintainer email="william@osrfoundation.org">William Woodall</maintainer>
 
     <license>BSD</license>
     <url type="website">http://ros.org/wiki/map_msgs</url>
     <url type="bugtracker">https://github.com/ros-planning/navigation_msgs/issues</url>
 
-    <buildtool_depend>catkin</buildtool_depend>
+    <buildtool_depend>ament_cmake</buildtool_depend>
 
-    <build_depend>message_generation</build_depend>
-    <build_depend>std_msgs</build_depend>
-    <build_depend>sensor_msgs</build_depend>
+    <buildtool_depend>rosidl_default_generators</buildtool_depend>
+
     <build_depend>nav_msgs</build_depend>
+    <build_depend>sensor_msgs</build_depend>
+    <build_depend>std_msgs</build_depend>
 
-    <run_depend>message_runtime</run_depend>
-    <run_depend>std_msgs</run_depend>
-    <run_depend>sensor_msgs</run_depend>
-    <run_depend>nav_msgs</run_depend>
+    <exec_depend>nav_msgs</exec_depend>
+    <exec_depend>rosidl_default_runtime</exec_depend>
+    <exec_depend>sensor_msgs</exec_depend>
+    <exec_depend>std_msgs</exec_depend>
+
+    <test_depend>ament_lint_common</test_depend>
+
+    <member_of_group>rosidl_interface_packages</member_of_group>
 
 </package>

--- a/map_msgs/srv/GetPointMap.srv
+++ b/map_msgs/srv/GetPointMap.srv
@@ -1,3 +1,3 @@
-# Get the map as a sensor_msgs/PointCloud2 
+# Get the map as a sensor_msgs/PointCloud2
 ---
 sensor_msgs/PointCloud2 map

--- a/map_msgs/srv/SaveMap.srv
+++ b/map_msgs/srv/SaveMap.srv
@@ -1,2 +1,2 @@
 # Save the map to the filesystem
-std_msgs/String filename 
+std_msgs/String filename

--- a/move_base_msgs/ROS2_README.md
+++ b/move_base_msgs/ROS2_README.md
@@ -1,0 +1,1 @@
+TODO(wjwwood): port this when actions are supported

--- a/move_base_msgs/package.xml
+++ b/move_base_msgs/package.xml
@@ -3,11 +3,11 @@
     <version>1.13.0</version>
     <description>
 
-        Holds the action description and relevant messages for the move_base package
+        Holds the action description and relevant messages for the move_base package.
 
     </description>
     <author>Eitan Marder-Eppstein</author>
-    <author>contradict@gmail.com</author>
+    <author email="contradict@gmail.com">contradict@gmail.com</author>
     <maintainer email="davidvlu@gmail.com">David V. Lu!!</maintainer>
     <maintainer email="mferguson@fetchrobotics.com">Michael Ferguson</maintainer>
     <license>BSD</license>


### PR DESCRIPTION
DO NOT MERGE, this is just for reference, the `ros2` branch should remain separate for now.

Hi guys, I went ahead and ported `map_msgs` and put it on this `ros2` branch because we need it in the map display for rviz in ROS 2. I hope you guys don't mind that I put it on a branch rather than a fork.

This does a few things:

- `map_msgs`
  - adds myself as a maintainer, so that you guys don't have to support the ROS 2 branch alone
  - update the version to 2.0.0 (to avoid overlap with ROS 1 version for now)
  - update dependencies in package.xml to be ROS 2 style
  - update cmake code to use ament and do message generation in ROS 2
  - touchup the messages to remove trailing whitespace and use `std_msgs/Header` instead of `Header` (required in ROS 2)
- `move_base_msgs`
  - disable with `AMENT_IGNORE` file (like `CATKIN_IGNORE`) for now since actions are still being ported

If you guys could close this pull request as an indication that this is all ok, that would be great. At that point I'd open a new issue to track that `move_base_msgs` needs porting when actions are done in ROS 2.

Also, this repository may be able to have one branch for both ROS 1 and ROS 2 in the future, but that depends on some on going work to smooth migration. So I'll have to come back and touch things again when that's possible.

I also built this on top of https://github.com/ros-planning/navigation_msgs/pull/3 in the hope that gets merged at some point.

Please let me know if you guys have any issues with this or questions for me.

Thanks!