### PR TITLE
add missing separator

### DIFF
--- a/map_msgs/srv/ProjectedMapsInfo.srv
+++ b/map_msgs/srv/ProjectedMapsInfo.srv
@@ -1,1 +1,2 @@
 map_msgs/ProjectedMapInfo[] projected_maps_info
+---

--- a/map_msgs/srv/SaveMap.srv
+++ b/map_msgs/srv/SaveMap.srv
@@ -1,2 +1,3 @@
 # Save the map to the filesystem
 std_msgs/String filename
+---


### PR DESCRIPTION
Some of the `.srv` files are missing the `---` if there is no response content, but ROS 2 requires that to be there.

See: https://github.com/ros2/rviz/pull/267#issuecomment-396839299

Connects to ros2/rviz#99