### PR TITLE
port move_base_msgs to ROS2 actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,5 +2,4 @@
 
 This repository contains messages used by the
 [navigation stack](https://github.com/ros-planning/navigation).
-It is intended for use in ROS Jade and above. Prior to Jade some of these
-messages existed in the navigation repository.
+It is intended for use in ROS Dashing and above. Prior to Dashing actions were not supported in navigation2.

--- a/move_base_msgs/CMakeLists.txt
+++ b/move_base_msgs/CMakeLists.txt
@@ -2,15 +2,13 @@ cmake_minimum_required(VERSION 3.5)
 project(move_base_msgs)
 
 find_package(ament_cmake REQUIRED)
-find_package(builtin_interfaces REQUIRED)
 find_package(geometry_msgs REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
-find_package(std_msgs REQUIRED)
 find_package(action_msgs REQUIRED)
 
 rosidl_generate_interfaces(${PROJECT_NAME}
   "action/MoveBase.action"
-  DEPENDENCIES builtin_interfaces geometry_msgs std_msgs action_msgs
+  DEPENDENCIES geometry_msgs action_msgs
 )
 
 ament_export_dependencies(rosidl_default_runtime)

--- a/move_base_msgs/CMakeLists.txt
+++ b/move_base_msgs/CMakeLists.txt
@@ -1,25 +1,18 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(move_base_msgs)
 
-find_package(catkin REQUIRED
-  COMPONENTS
-    message_generation
-    actionlib_msgs
-    geometry_msgs
+find_package(ament_cmake REQUIRED)
+find_package(builtin_interfaces REQUIRED)
+find_package(geometry_msgs REQUIRED)
+find_package(rosidl_default_generators REQUIRED)
+find_package(std_msgs REQUIRED)
+find_package(action_msgs REQUIRED)
+
+rosidl_generate_interfaces(${PROJECT_NAME}
+  "action/MoveBase.action"
+  DEPENDENCIES builtin_interfaces geometry_msgs std_msgs action_msgs
 )
 
-add_action_files(
-  DIRECTORY
-    action
-  FILES
-    MoveBase.action
-)
+ament_export_dependencies(rosidl_default_runtime)
 
-generate_messages(
-  DEPENDENCIES
-    actionlib_msgs
-    geometry_msgs
-)
-
-catkin_package(
-)
+ament_package()

--- a/move_base_msgs/CMakeLists.txt
+++ b/move_base_msgs/CMakeLists.txt
@@ -2,13 +2,14 @@ cmake_minimum_required(VERSION 3.5)
 project(move_base_msgs)
 
 find_package(ament_cmake REQUIRED)
+
+find_package(action_msgs REQUIRED)
 find_package(geometry_msgs REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
-find_package(action_msgs REQUIRED)
 
 rosidl_generate_interfaces(${PROJECT_NAME}
   "action/MoveBase.action"
-  DEPENDENCIES geometry_msgs action_msgs
+  DEPENDENCIES action_msgs geometry_msgs
 )
 
 ament_export_dependencies(rosidl_default_runtime)

--- a/move_base_msgs/ROS2_README.md
+++ b/move_base_msgs/ROS2_README.md
@@ -1,1 +1,0 @@
-TODO(wjwwood): port this when actions are supported

--- a/move_base_msgs/package.xml
+++ b/move_base_msgs/package.xml
@@ -1,4 +1,6 @@
-<package>
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
     <name>move_base_msgs</name>
     <version>2.0.0</version>
     <description>
@@ -10,19 +12,21 @@
     <author email="contradict@gmail.com">contradict@gmail.com</author>
     <maintainer email="davidvlu@gmail.com">David V. Lu!!</maintainer>
     <maintainer email="mferguson@fetchrobotics.com">Michael Ferguson</maintainer>
+    <maintainer email="stevenmacenski@gmail.com">Steve Macenski</maintainer>
     <license>BSD</license>
     <url type="website">http://wiki.ros.org/move_base_msgs</url>
     <url type="bugtracker">https://github.com/ros-planning/navigation_msgs/issues</url>
 
-    <buildtool_depend>catkin</buildtool_depend>
+    <buildtool_depend>ament_cmake</buildtool_depend>
 
-    <build_depend>actionlib_msgs</build_depend>
-    <build_depend>geometry_msgs</build_depend>
-    <build_depend>message_generation</build_depend>
+    <depend>builtin_interfaces</depend>
+    <depend>rosidl_default_generators</depend>
 
-    <run_depend>actionlib_msgs</run_depend>
-    <run_depend>geometry_msgs</run_depend>
-    <run_depend>message_runtime</run_depend>
+    <depend>action_msgs</depend>
+    <depend>geometry_msgs</depend>
 
+    <member_of_group>rosidl_interface_packages</member_of_group>
+    <export>
+      <build_type>ament_cmake</build_type>
+    </export>
 </package>
-

--- a/move_base_msgs/package.xml
+++ b/move_base_msgs/package.xml
@@ -19,8 +19,8 @@
 
     <buildtool_depend>ament_cmake</buildtool_depend>
 
-    <depend>builtin_interfaces</depend>
-    <depend>rosidl_default_generators</depend>
+    <build_depend>rosidl_default_generators</build_depend>
+    <exec_depend>rosidl_default_runtime</exec_depend>
 
     <depend>action_msgs</depend>
     <depend>geometry_msgs</depend>

--- a/move_base_msgs/package.xml
+++ b/move_base_msgs/package.xml
@@ -10,8 +10,8 @@
     </description>
     <author>Eitan Marder-Eppstein</author>
     <author email="contradict@gmail.com">contradict@gmail.com</author>
-    <maintainer email="davidvlu@gmail.com">David V. Lu!!</maintainer>
-    <maintainer email="mferguson@fetchrobotics.com">Michael Ferguson</maintainer>
+    <author email="davidvlu@gmail.com">David V. Lu!!</author>
+    <author email="mferguson@fetchrobotics.com">Michael Ferguson</author>
     <maintainer email="stevenmacenski@gmail.com">Steve Macenski</maintainer>
     <license>BSD</license>
     <url type="website">http://wiki.ros.org/move_base_msgs</url>


### PR DESCRIPTION
@wjwwood I answered your note for porting after actions were enabled in ROS2. It's one of the last things not available in apt for navigation2 dependencies

![img](https://media2.giphy.com/media/Lm63QU87HvgVEuTV63/giphy.gif)