### PR TITLE
Bump CMake version to avoid CMP0048

### DIFF
--- a/map_msgs/CMakeLists.txt
+++ b/map_msgs/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(map_msgs)
 
 find_package(catkin REQUIRED

--- a/move_base_msgs/CMakeLists.txt
+++ b/move_base_msgs/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(move_base_msgs)
 
 find_package(catkin REQUIRED


### PR DESCRIPTION
This bumps the minimum CMake version to 3.0.2, which is the [minimum supported by ROS Kinetic](https://www.ros.org/reps/rep-0003.html#kinetic-kame-may-2016-may-2021) and new enough to default to the NEW behavior of [CMP0048](https://cmake.org/cmake/help/v3.0/policy/CMP0048.html). This avoids a CMake warning when building and testing this package in Debian Buster and Ubuntu Focal.

ros/catkin#1052